### PR TITLE
Mention Python 3.14 works

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ which uses `lean3`.
 ## Overview
 
 We need
-- an old version of `python` e.g. 3.5.4
+- an old version of `python` e.g. 3.5.4 (although Python versions as new as 3.14 have been found to work)
 - the virtual environment for this version of `python`
 - `convert` from [imagemagick](https://imagemagick.org/)
 - `xelatex` and `latexmk`


### PR DESCRIPTION
This is really important for others who want to build - even just installing these Python versions is a huge effort if there are no prebuilt binaries available. I managed to get my hands on Python 3.5, but that was on Distrobox (Podman/Docker backend) so I wouldn't have known how I could have interfaced it with the Python virtual environment requirement. Luckily I was able to forget all of that this time as `uv venv` did the job just as well.